### PR TITLE
Updated to latest GMusic API. Corrected line number on the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This is a incredibly simple script, but does require a few small configurations.
 * If you do not have pip or are running windows, please see [Unofficial Google Music API usage](http://unofficial-google-music-api.readthedocs.org/en/latest/usage.html)
 
 ### Change login credentials
-* Near line 49, change the 'username' and 'password' to your Google account credentials.
+* Near line 89, change the 'username' and 'password' to your Google account credentials.
 
 ### Run kill_dupes
 * The script will automatically detect and remove duplicates on any songs in your library.

--- a/kill_dupes
+++ b/kill_dupes
@@ -86,7 +86,7 @@ def get_track_ids(tracks):
 
 
 api = Mobileclient()
-logged_in = api.login('username', 'password')
+logged_in = api.login('username', 'password', Mobileclient.FROM_MAC_ADDRESS)
 
 if logged_in:
     print "Successfully logged in. Beginning duplicate detection process."


### PR DESCRIPTION
The latest GMusic API needs an extra parameter (Android ID) for login, but also provides a handy shortcut for generating an ID from a MAC address, which is what we use here.