### PR TITLE
raw_input() not found.

### DIFF
--- a/kill_dupes
+++ b/kill_dupes
@@ -65,7 +65,7 @@ def get_duplicate_tracks(all_tracks_by_album, album_track_duplicate_map):
 
 
 def query_yes_no(question, default="yes"):
-    """Ask a yes/no question via raw_input() and return their answer.
+    """Ask a yes/no question via input() and return their answer.
 
     "question" is a string that is presented to the user.
     "default" is the presumed answer if the user just hits <Enter>.
@@ -87,7 +87,7 @@ def query_yes_no(question, default="yes"):
 
     while True:
         sys.stdout.write(question + prompt)
-        choice = raw_input().lower()
+        choice = input().lower()
         if default is not None and choice == '':
             return valid[default]
         elif choice in valid:


### PR DESCRIPTION
raw_input() was renamed input() in python 3. I'm not sure why it was changed back to raw_input(), maybe python2 was run on the file even though the header has python3? Otherwise this error occurs:

  File "kill_dupes", line 118, in <module>
    if query_yes_no("Found " + str(len(duplicate_track_ids)) + " duplicate tracks. Delete duplicates?", "no"):
  File "kill_dupes", line 90, in query_yes_no
    choice = raw_input().lower()
NameError: name 'raw_input' is not defined