### PR TITLE
Optionally import credentials from external file and resolve #28

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 .project
 .pydevproject
+credentials.py

--- a/README.md
+++ b/README.md
@@ -17,10 +17,24 @@ These are incredibly simple scripts, but do require a few small configurations.
 * If you do not have pip or are running windows, please see [Unofficial Google Music API usage](http://unofficial-google-music-api.readthedocs.org/en/latest/usage.html)
 
 ### Change login credentials
-* Near line 89, change the 'username' and 'password' to your Google account credentials.
+* Near line 12 in the script, change the 'username' and 'password' to your Google account credentials. 
+* Alternatively, create an empty file calleded 'credentials.py' in the script directory and set the username and password variables there.
+
+```python
+# credentials.py
+username = 'changeme@gmail.com'
+password = 'changeme'
+#android_id = 'deadbeefc0decafe'
+```
+
 * NOTE: Users with 2-step authentication enabled will have to create an App Specific Key/Password.
 Login into your Google account and head to https://security.google.com/settings/security/apppasswords, there you will be able to manually generate an App Specific password.
 After creating the Key/Password, just use it to login into this App, together with your usual Google username/email.
+
+* NOTE: If you see the error message "a valid MAC could not be determined."
+you are running into a [known issue](https://github.com/simon-weber/gmusicapi/issues/408) with the Google Music API.
+
+To workaround, set a new 16 digit hexadecimal number as your android_id on line 17 or in credentials.py.
 
 ### Run kill_dupes
 * The script will automatically detect and remove duplicates on any songs in your library.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ These are incredibly simple scripts, but do require a few small configurations.
 
 ### Change login credentials
 * Near line 12 in the script, change the 'username' and 'password' to your Google account credentials. 
-* Alternatively, create an empty file calleded 'credentials.py' in the script directory and set the username and password variables there.
+* Alternatively, create an empty file called 'credentials.py' in the script directory and set the username and password variables there.
 
 ```python
 # credentials.py
@@ -33,7 +33,6 @@ After creating the Key/Password, just use it to login into this App, together wi
 
 * NOTE: If you see the error message "a valid MAC could not be determined."
 you are running into a [known issue](https://github.com/simon-weber/gmusicapi/issues/408) with the Google Music API.
-
 To workaround, set a new 16 digit hexadecimal number as your android_id on line 17 or in credentials.py.
 
 ### Run kill_dupes

--- a/kill_dupes
+++ b/kill_dupes
@@ -3,6 +3,21 @@ import sys
 
 from gmusicapi import Mobileclient
 
+try:
+    import credentials
+    # credentials.py is in .gitignore and can be shared with other scripts
+    username = credentials.username
+    password = credentials.password
+except ImportError:
+    username = 'username'
+    password = 'password'
+
+try:
+    # optionally hardcode id to workaround https://github.com/simon-weber/gmusicapi/issues/408
+    android_id = credentials.android_id
+except (NameError, AttributeError):
+    android_id = Mobileclient.FROM_MAC_ADDRESS
+
 
 def map_track_duplication(tracks):
     album_track_duplicate_map = {}
@@ -109,7 +124,7 @@ def get_track_ids(tracks):
 
 
 api = Mobileclient()
-logged_in = api.login('username', 'password', Mobileclient.FROM_MAC_ADDRESS)
+logged_in = api.login(username, password, android_id)
 
 if logged_in:
     print("Successfully logged in. Beginning duplicate detection process.")

--- a/kill_playlist_dupes
+++ b/kill_playlist_dupes
@@ -3,7 +3,20 @@ import sys
 
 from gmusicapi import Mobileclient
 
+try:
+    import credentials
+    # credentials.py is in .gitignore and can be shared with other scripts
+    username = credentials.username
+    password = credentials.password
+except ImportError:
+    username = 'username'
+    password = 'password'
 
+try:
+    # optionally hardcode id to workaround https://github.com/simon-weber/gmusicapi/issues/408
+    android_id = credentials.android_id
+except (NameError, AttributeError):
+    android_id = Mobileclient.FROM_MAC_ADDRESS
 
 def get_dupes_in_playlist(playlist):
    duplicate_Ids = []
@@ -58,7 +71,7 @@ def query_yes_no(question, default="yes"):
 
 
 api = Mobileclient()
-logged_in = api.login('username', 'password', Mobileclient.FROM_MAC_ADDRESS)
+logged_in = api.login(username, password, android_id)
 
 if logged_in:
     print("Successfully logged in. Beginning duplicate detection process.")


### PR DESCRIPTION
Add support for optional credentials.py

 - Allows sharing user credentials between scripts.
 - Prevents accidental public commits of live credentials.

Users can now easily specifiy an android_id other than FROM_MAC_ADDRESS

 - Workaround for https://github.com/simon-weber/gmusicapi/issues/408
 - android_id can also be specified in the optional credentials file

Resolves: #28