### PR TITLE
Fallback input() to raw_input() before python 3

### DIFF
--- a/kill_dupes
+++ b/kill_dupes
@@ -91,7 +91,11 @@ def query_yes_no(question, default="yes"):
 
     while True:
         sys.stdout.write(question + prompt)
-        choice = input().lower()
+        if sys.version_info[0] < 3:
+            choice = raw_input().lower()
+        else:
+            choice = input().lower()
+            
         if default is not None and choice == '':
             return valid[default]
         elif choice in valid:

--- a/kill_playlist_dupes
+++ b/kill_playlist_dupes
@@ -47,7 +47,10 @@ def query_yes_no(question, default="yes"):
 
     while True:
         sys.stdout.write(question + prompt)
-        choice = input().lower()
+        if sys.version_info[0] < 3:
+            choice = raw_input().lower()
+        else:
+            choice = input().lower()
         if default is not None and choice == '':
             return valid[default]
         elif choice in valid:


### PR DESCRIPTION
Better fix for #30, #26 and #24 by deciding input function based on python version.

This is better than hard-coding the python 3 builtin input(), which fails on python 2, prompting folks to raise issues (or worse, pull requests changing it back).

Resolves: #30