### PR TITLE
FIX: KeyError on get_duplicate_tracks

### DIFF
--- a/kill_dupes
+++ b/kill_dupes
@@ -68,7 +68,10 @@ def get_duplicate_tracks(all_tracks_by_album, album_track_duplicate_map):
                                 for track in all_tracks_by_album[album]:
                                     titleNorm = track['title'].lower()
                                     if titleNorm == track_title:
-                                        trackNumberNorm = track['trackNumber']
+                                        try:
+                                            trackNumberNorm = track['trackNumber']
+                                        except:    
+                                            trackNumberNorm = 0
                                         if trackNumberNorm == track_number:
                                             try:
                                                 discNumberNorm = track['discNumber']


### PR DESCRIPTION
Solved this error:
`Traceback (most recent call last):
  File "./kill_dupes", line 141, in <module>
    duplicate_tracks = get_duplicate_tracks(all_tracks_by_album, album_track_duplicate_map)
  File "./kill_dupes", line 77, in get_duplicate_tracks
    discNumberNorm = track['discNumber']
KeyError: 'discNumber'`
